### PR TITLE
Update dependencies to latest versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 		<dependency>
 			<groupId>org.springdoc</groupId>
 			<artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
-			<version>2.6.0</version>
+			<version>2.8.5</version>
 		</dependency>
 
 		<!-- Lombok Dependency -->
@@ -79,7 +79,7 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
-			<version>5.9.3</version>
+			<version>5.12.0</version>
 			<scope>test</scope>
 		</dependency>
 


### PR DESCRIPTION
Updated project dependencies to their latest versions:
- springdoc-openapi-starter-webmvc-ui: 2.6.0 → 2.8.5
- junit-jupiter: 5.9.3 → 5.12.0

All tests pass successfully after updates.